### PR TITLE
Added identification middleware

### DIFF
--- a/middleware/identification.go
+++ b/middleware/identification.go
@@ -1,0 +1,21 @@
+package middleware
+
+import (
+	"github.com/HackIllinois/api-gateway/utils"
+	"net/http"
+)
+
+func IdentificationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		id, err := utils.ExtractFieldFromJWT(token, "id")
+
+		if err == nil {
+			r.Header.Set("HackIllinois-Identity", id[0])
+		} else {
+			r.Header.Set("HackIllinois-Identity", "")
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/services/auth.go
+++ b/services/auth.go
@@ -17,25 +17,25 @@ var AuthRoutes = arbor.RouteCollection{
 		"OauthRedirect",
 		"GET",
 		"/auth/{provider}/",
-		alice.New().ThenFunc(OauthRedirect).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware).ThenFunc(OauthRedirect).ServeHTTP,
 	},
 	arbor.Route{
 		"OauthCode",
 		"POST",
 		"/auth/code/{provider}/",
-		alice.New().ThenFunc(OauthCode).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware).ThenFunc(OauthCode).ServeHTTP,
 	},
 	arbor.Route{
 		"GetUserRoles",
 		"GET",
 		"/auth/roles/{id}/",
-		alice.New(middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(GetUserRoles).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(GetUserRoles).ServeHTTP,
 	},
 	arbor.Route{
 		"SetUserRoles",
 		"PUT",
 		"/auth/roles/",
-		alice.New(middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(SetUserRoles).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(SetUserRoles).ServeHTTP,
 	},
 }
 

--- a/services/registration.go
+++ b/services/registration.go
@@ -17,25 +17,25 @@ var RegistrationRoutes = arbor.RouteCollection{
 		"GetCurrentRegistrationInfo",
 		"GET",
 		"/user/",
-		alice.New(middleware.AuthMiddleware([]string{"User"})).ThenFunc(GetCurrentRegistrationInfo).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"User"})).ThenFunc(GetCurrentRegistrationInfo).ServeHTTP,
 	},
 	arbor.Route{
 		"CreateCurrentRegistrationInfo",
 		"POST",
 		"/user/",
-		alice.New(middleware.AuthMiddleware([]string{"User"})).ThenFunc(CreateCurrentRegistrationInfo).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"User"})).ThenFunc(CreateCurrentRegistrationInfo).ServeHTTP,
 	},
 	arbor.Route{
 		"UpdateCurrentRegistrationInfo",
 		"PUT",
 		"/user/",
-		alice.New(middleware.AuthMiddleware([]string{"Attendee"})).ThenFunc(UpdateCurrentRegistrationInfo).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Attendee"})).ThenFunc(UpdateCurrentRegistrationInfo).ServeHTTP,
 	},
 	arbor.Route{
 		"GetRegistrationInfo",
 		"GET",
 		"/user/{id}/",
-		alice.New(middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(GetRegistrationInfo).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(GetRegistrationInfo).ServeHTTP,
 	},
 }
 

--- a/services/test.go
+++ b/services/test.go
@@ -17,19 +17,19 @@ var TestRoutes = arbor.RouteCollection{
 		"UserAuth",
 		"POST",
 		"/test/userauth/",
-		alice.New(middleware.AuthMiddleware([]string{"User"})).ThenFunc(UserAuth).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"User"})).ThenFunc(UserAuth).ServeHTTP,
 	},
 	arbor.Route{
 		"AdminAuth",
 		"POST",
 		"/test/adminauth/",
-		alice.New(middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(AdminAuth).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(AdminAuth).ServeHTTP,
 	},
 	arbor.Route{
 		"NoAuth",
 		"POST",
 		"/test/noauth/",
-		alice.New().ThenFunc(NoAuth).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware).ThenFunc(NoAuth).ServeHTTP,
 	},
 }
 

--- a/services/user.go
+++ b/services/user.go
@@ -17,19 +17,19 @@ var UserRoutes = arbor.RouteCollection{
 		"GetCurrentUserInfo",
 		"GET",
 		"/user/",
-		alice.New(middleware.AuthMiddleware([]string{"User"})).ThenFunc(GetCurrentUserInfo).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"User"})).ThenFunc(GetCurrentUserInfo).ServeHTTP,
 	},
 	arbor.Route{
 		"GetUserInfo",
 		"GET",
 		"/user/{id}/",
-		alice.New(middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(GetUserInfo).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(GetUserInfo).ServeHTTP,
 	},
 	arbor.Route{
 		"SetUserInfo",
 		"POST",
 		"/user/",
-		alice.New(middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(SetUserInfo).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(SetUserInfo).ServeHTTP,
 	},
 }
 


### PR DESCRIPTION
Addersses #7 

- [x] Put the user's id from their JWT into the HackIllinois-Identity header before passing the request through
- [x] The contents of HackIllinois-Identity are cleared for every request before replacing the contents the id from the JWT. This is prevent users from sending the header with their original request.