### PR TITLE
Added route /auth/refresh/token/

### DIFF
--- a/services/auth.go
+++ b/services/auth.go
@@ -42,7 +42,7 @@ var AuthRoutes = arbor.RouteCollection{
 		"RefreshToken",
 		"GET",
 		"/auth/token/refresh/",
-		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(RefreshToken).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"User"})).ThenFunc(RefreshToken).ServeHTTP,
 	},
 }
 

--- a/services/auth.go
+++ b/services/auth.go
@@ -1,11 +1,12 @@
 package services
 
 import (
+	"net/http"
+
 	"github.com/HackIllinois/api-gateway/config"
 	"github.com/HackIllinois/api-gateway/middleware"
 	"github.com/arbor-dev/arbor"
 	"github.com/justinas/alice"
-	"net/http"
 )
 
 var AuthURL = config.AUTH_SERVICE
@@ -37,6 +38,12 @@ var AuthRoutes = arbor.RouteCollection{
 		"/auth/roles/",
 		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(SetUserRoles).ServeHTTP,
 	},
+	arbor.Route{
+		"RefreshToken",
+		"GET",
+		"/auth/token/refresh/",
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(RefreshToken).ServeHTTP,
+	},
 }
 
 func OauthRedirect(w http.ResponseWriter, r *http.Request) {
@@ -53,4 +60,8 @@ func GetUserRoles(w http.ResponseWriter, r *http.Request) {
 
 func SetUserRoles(w http.ResponseWriter, r *http.Request) {
 	arbor.PUT(w, AuthURL+r.URL.String(), AuthFormat, "", r)
+}
+
+func RefreshToken(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, AuthURL+r.URL.String(), AuthFormat, "", r)
 }


### PR DESCRIPTION
I'm not fully sure what I did, or if it's the right thing, but I appended a route to a list, with a `ThenFunction` set to a `GET` request pointed at `/auth/token/refresh/`.

I noticed that there were many other functions only differing in the type of request. Do we intend to do more with the `ThenFunction`s in the future, or can we just have a generic stub for each of the different types of requests (GET, POST, PUT, DELETE etc.)?

- [ ] Added route /auth/token/refresh/(?)