### PR TITLE
Admin impersonation

### DIFF
--- a/middleware/identification.go
+++ b/middleware/identification.go
@@ -10,37 +10,25 @@ func IdentificationMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := r.Header.Get("Authorization")
 		id, err := utils.ExtractFieldFromJWT(token, "id")
-
 		if err == nil {
 			//Check if the user has role "Admin"
 			is_admin, err := utils.HasRole(token, "Admin")
-
-			if err == nil {
-				if is_admin {
-					impersonation_id := r.Header.Get("HackIllinois-Impersonation")
-
-					// Check if an impersonation ID is specified
-					// According to https://golang.org/src/net/http/header.go:37, Get returns an empty
-					// string if there is no value associated with a given header.
-
-					if impersonation_id == "" {
-						r.Header.Set("HackIllinois-Identity", id[0])
-					} else {
-						// Sets ID to the one specified by a user with role "Admin"
-						r.Header.Set("HackIllinois-Identity", impersonation_id)
-					}
-				} else {
+			if err == nil && is_admin {
+				impersonation_id := r.Header.Get("HackIllinois-Impersonation")
+				// Check if an impersonation ID is specified
+				if impersonation_id == "" {
 					r.Header.Set("HackIllinois-Identity", id[0])
+				} else {
+					// Sets ID to the one specified by a user with role "Admin"
+					r.Header.Set("HackIllinois-Identity", impersonation_id)
 				}
 			} else {
-				// Unable to determine the user's roles
 				r.Header.Set("HackIllinois-Identity", id[0])
 			}
 		} else {
 			// Cannot retrieve user's ID
 			r.Header.Set("HackIllinois-Identity", "")
 		}
-
 		next.ServeHTTP(w, r)
 	})
 }

--- a/middleware/identification.go
+++ b/middleware/identification.go
@@ -20,7 +20,8 @@ func IdentificationMiddleware(next http.Handler) http.Handler {
 					impersonation_id := r.Header.Get("HackIllinois-Impersonation")
 
 					// Check if an impersonation ID is specified
-					// According to https://golang.org/src/net/http/header.go:37, Get returns an empty string if there is no value associated with a given header.
+					// According to https://golang.org/src/net/http/header.go:37, Get returns an empty
+					// string if there is no value associated with a given header.
 
 					if impersonation_id == "" {
 						r.Header.Set("HackIllinois-Identity", id[0])

--- a/middleware/identification.go
+++ b/middleware/identification.go
@@ -1,8 +1,9 @@
 package middleware
 
 import (
-	"github.com/HackIllinois/api-gateway/utils"
 	"net/http"
+
+	"github.com/HackIllinois/api-gateway/utils"
 )
 
 func IdentificationMiddleware(next http.Handler) http.Handler {
@@ -11,8 +12,31 @@ func IdentificationMiddleware(next http.Handler) http.Handler {
 		id, err := utils.ExtractFieldFromJWT(token, "id")
 
 		if err == nil {
-			r.Header.Set("HackIllinois-Identity", id[0])
+			//Check if the user has role "Admin"
+			is_admin, err := utils.HasRole(token, "Admin")
+
+			if err == nil {
+				if is_admin {
+					impersonation_id := r.Header.Get("HackIllinois-Impersonation")
+
+					// Check if an impersonation ID is specified
+					// According to https://golang.org/src/net/http/header.go:37, Get returns an empty string if there is no value associated with a given header.
+
+					if impersonation_id == "" {
+						r.Header.Set("HackIllinois-Identity", id[0])
+					} else {
+						// Sets ID to the one specified by a user with role "Admin"
+						r.Header.Set("HackIllinois-Identity", impersonation_id)
+					}
+				} else {
+					r.Header.Set("HackIllinois-Identity", id[0])
+				}
+			} else {
+				// Unable to determine the user's roles
+				r.Header.Set("HackIllinois-Identity", id[0])
+			}
 		} else {
+			// Cannot retrieve user's ID
 			r.Header.Set("HackIllinois-Identity", "")
 		}
 


### PR DESCRIPTION
- [x] Admin impersonation for testing and debugging implemented by allowing Admins to specify the `id` placed into the `HackIllinois-Identity` header in place of their own `id`

This was done by checking for the `Admin` role in the user's token in the Identification middleware. If this role was present, the `HackIllinois-Impersonation` header was checked to see if an `id` was set. If the header had an `id` set, then this `id` was placed into the `HackIllinois-Identity` header instead of the `id` in the auth token.

Implements feature requested in issue #11.